### PR TITLE
 1103-inspired drop-dash script thing, S1 animations for Sonic and peelout cancel

### DIFF
--- a/scripts/animations/s1animations.lemon
+++ b/scripts/animations/s1animations.lemon
@@ -11,28 +11,28 @@
 // Author Notes
 /*
 
-    This changes some of Sonic's animations to their Sonic 1 versions (for example, 6 frame walk and 2 frame ledge teeter).
-    This is designed for use in skin mods.
-    
+	This changes some of Sonic's animations to their Sonic 1 versions (for example, 6 frame walk and 2 frame ledge teeter).
+	This is designed for use in skin mods.
+	
 */
 
 //# address-hook(0x010a94) end(0x010ae8)
 function void Character.BaseUpdate.Sonic()
 {
 	base.Character.BaseUpdate.Sonic()
-    // 6 frame walk
+	// 6 frame walk
 	if (char.animation.sprite < 29 && char.animation.frame == 2 && char.state == char.state.RUNNING) // If walking and on frame 2, set frame to 4.
 		char.animation.frame = 4 // The first 2 animation frames are skipped.
-        
-    // 1 frame victory animation
-    if (char.animation.sprite == 178 || char.animation.sprite == 179)
+		
+	// 1 frame victory animation
+	if (char.animation.sprite == 178 || char.animation.sprite == 179)
 	{
 		char.animation.sprite = 177
 		char.animation.frame = 8
 	}
-    
-    // 2 frame ledge teeters
-    if (char.animation.sprite == 166)
+	
+	// 2 frame ledge teeters
+	if (char.animation.sprite == 166)
 	{
 		char.animation.sprite = 164
 		char.animation.frame = 1	
@@ -42,9 +42,9 @@ function void Character.BaseUpdate.Sonic()
 		char.animation.sprite = 161
 		char.animation.frame = 1	
 	}
-    
-    // Infinite 2 frame waiting animation
-    if (char.animation.sprite == 0xad || char.animation.sprite == 0xd9 || char.animation.sprite == 0xaf || char.animation.sprite == 0xae)
+	
+	// Infinite 2 frame waiting animation
+	if (char.animation.sprite == 0xad || char.animation.sprite == 0xd9 || char.animation.sprite == 0xaf || char.animation.sprite == 0xae)
 	{
 		char.animation.sprite = 0xbe
 		char.animation.frame -= 5

--- a/scripts/animations/s1animations.lemon
+++ b/scripts/animations/s1animations.lemon
@@ -21,7 +21,7 @@ function void Character.BaseUpdate.Sonic()
 {
 	base.Character.BaseUpdate.Sonic()
     // 6 frame walk
-	if (char.animation.sprite < 29 && char.animation.frame == 2 && (char.state == char.state.RUNNING)) // If walking and on frame 2, set frame to 4.
+	if (char.animation.sprite < 29 && char.animation.frame == 2 && char.state == char.state.RUNNING) // If walking and on frame 2, set frame to 4.
 		char.animation.frame = 4 // The first 2 animation frames are skipped.
         
     // 1 frame victory animation
@@ -37,7 +37,7 @@ function void Character.BaseUpdate.Sonic()
 		char.animation.sprite = 164
 		char.animation.frame = 1	
 	}
-	if (char.animation.sprite == 163)
+	else if (char.animation.sprite == 163)
 	{
 		char.animation.sprite = 161
 		char.animation.frame = 1	

--- a/scripts/animations/s1animations.lemon
+++ b/scripts/animations/s1animations.lemon
@@ -1,0 +1,52 @@
+/*
+
+	This script file is part of the Sonic 3 A.I.R. Modders Resource. The Modders
+	Resource is a free resource library for any 3 A.I.R. modder, and for any
+	non-commercial purpose. No permission to use needed, no crediting required!
+
+	Come check it out at https://github.com/AirWay1/3AIR-Mod-Resources!
+
+*/
+
+// Author Notes
+/*
+
+    This changes some of Sonic's animations to their Sonic 1 versions (for example, 6 frame walk and 2 frame ledge teeter).
+    This is designed for use in skin mods.
+    
+*/
+
+//# address-hook(0x010a94) end(0x010ae8)
+function void Character.BaseUpdate.Sonic()
+{
+	base.Character.BaseUpdate.Sonic()
+    // 6 frame walk
+	if (char.animation.sprite < 29 && char.animation.frame == 2 && (char.state == char.state.RUNNING)) // If walking and on frame 2, set frame to 4.
+		char.animation.frame = 4 // The first 2 animation frames are skipped.
+        
+    // 1 frame victory animation
+    if (char.animation.sprite == 178 || char.animation.sprite == 179)
+	{
+		char.animation.sprite = 177
+		char.animation.frame = 8
+	}
+    
+    // 2 frame ledge teeters
+    if (char.animation.sprite == 166)
+	{
+		char.animation.sprite = 164
+		char.animation.frame = 1	
+	}
+	if (char.animation.sprite == 163)
+	{
+		char.animation.sprite = 161
+		char.animation.frame = 1	
+	}
+    
+    // Infinite 2 frame waiting animation
+    if (char.animation.sprite == 0xad || char.animation.sprite == 0xd9 || char.animation.sprite == 0xaf || char.animation.sprite == 0xae)
+	{
+		char.animation.sprite = 0xbe
+		char.animation.frame -= 5
+	}
+}

--- a/scripts/moves/1103-inspired-dropdash.lemon
+++ b/scripts/moves/1103-inspired-dropdash.lemon
@@ -1,0 +1,119 @@
+/*
+
+	This script file is part of the Sonic 3 A.I.R. Modders Resource. The Modders
+	Resource is a free resource library for any 3 A.I.R. modder, and for any
+	non-commercial purpose. No permission to use needed, no crediting required!
+
+	Come check it out at https://github.com/AirWay1/3AIR-Mod-Resources!
+
+*/
+
+// Author Notes
+/*
+
+	This disables the peel-out and edits the drop-dash to function somewhat similarly to the Sonic 3 1103 prototype.
+    Hold Up and Jump in the air in order to drop-dash.
+
+*/
+
+function bool Character.updateSuperPeelout()
+{
+	return false
+}
+
+function void Character.updateJumpMoves()
+{
+	u8 input_state     = (char.character == CHARACTER_TAILS) ? control.tails.state   : control.player1.state
+	u8 input_pressed   = (char.character == CHARACTER_TAILS) ? control.tails.pressed : control.player1.pressed
+	bool isSuperActive = (char.character == CHARACTER_TAILS) ? super.active.tails    : super.active
+
+	if (char.jumping)
+	{
+		// Limit velocity.y
+		s16 max_vy = (char.flags & char.flag.UNDERWATER) ? -0x200 : -0x400
+		if (char.velocity.y < max_vy)
+		{
+			// Limit vertical velocity while not pressing any jump button
+			//  -> This is important to support low jumps by just tapping the button briefly
+			if ((input_state & CONTROL_ABC) == 0)
+			{
+				char.velocity.y = max_vy
+			}
+		}
+		else
+		{
+			if (char.double_jump_state == 0)
+			{
+					if (Input.buttonPressed(BUTTON_Y))
+					{
+						if (!isSuperActive && char.invuln.countdown == 0)	// Check invulnerability to prevent spamming of super activate + cancel
+						{
+							if (Character.performSuperTransformation())
+								return
+						}
+					}
+
+				// Check if pressed jump again in mid-air
+				if (input_pressed & CONTROL_ABC)
+				{
+					// Check for other things to do instead of the usual reaction to jump button pressed
+					if (onCharacterPressedJumpInMidAir(input_state, input_pressed))
+					{
+						if (char.character == CHARACTER_SONIC)
+						{
+							SonicPressedJumpInMidAir()
+						}
+						else if (char.character == CHARACTER_TAILS)
+						{
+							TailsPressedJumpInMidAir()
+						}
+						else if (!competition_mode.active)
+						{
+							KnucklesPressedJumpInMidAir()
+						}
+						else
+						{
+							// Knuckles behaves just like Sonic in competition mode
+							SonicPressedJumpInMidAir()
+						}
+					}
+				}
+			}
+			if (Game.getSetting(SETTING_DROPDASH) && char.character == CHARACTER_SONIC && !competition_mode.active)
+			{
+				// Handle drop dash
+				//  -> Can only be charged if there is no shield active (only exception: drop dash charge started already, when shield gets active -- this reflects Sonic Mania's behavior)
+				//  -> But can be charged if invincible (incl. Super / Hyper Sonic)
+				bool chargeDropDash = (control.player1.state & CONTROL_ABC) && (control.player1.state & CONTROL_UP) && ((char.bonus_effect & 0x70) == 0 || (char.bonus_effect & char.bonus.INVINCIBLE) || sonic.dropdash_counter > 0) && !(char.double_jump_state)
+                // This checks for Up being held.
+				if (chargeDropDash)
+				{
+					if (sonic.dropdash_counter < DROPDASH_FULLCHARGE)
+					{
+						// Drop dash charging
+						++sonic.dropdash_counter
+						if (sonic.dropdash_counter == DROPDASH_FULLCHARGE)
+						{
+							// Fully charged now
+							char.state = char.state.SONIC_DROPDASH
+							Audio.playAudio("dropdash_charge", AudioContext.CONTEXT_SOUND)
+						}
+					}
+				}
+				else if (sonic.dropdash_counter > 0)
+				{
+					// Abort drop dash
+					sonic.dropdash_counter = 0
+					char.state = char.state.ROLLING
+				}
+			}
+		}
+	}
+	else
+	{
+		if (char.spindash == 0)
+		{
+			char.velocity.y = max(char.velocity.y, -0x0fc0)
+		}
+	}
+}

--- a/scripts/moves/1103-inspired-dropdash.lemon
+++ b/scripts/moves/1103-inspired-dropdash.lemon
@@ -12,7 +12,7 @@
 /*
 
 	This disables the peel-out and edits the drop-dash to function somewhat similarly to the Sonic 3 1103 prototype.
-    Hold Up and Jump in the air in order to drop-dash.
+	Hold Up and Jump in the air in order to drop-dash.
 
 */
 
@@ -23,9 +23,9 @@ function bool Character.updateSuperPeelout()
 
 function void Character.updateJumpMoves()
 {
-	u8 input_state     = (char.character == CHARACTER_TAILS) ? control.tails.state   : control.player1.state
+	u8 input_state	 = (char.character == CHARACTER_TAILS) ? control.tails.state   : control.player1.state
 	u8 input_pressed   = (char.character == CHARACTER_TAILS) ? control.tails.pressed : control.player1.pressed
-	bool isSuperActive = (char.character == CHARACTER_TAILS) ? super.active.tails    : super.active
+	bool isSuperActive = (char.character == CHARACTER_TAILS) ? super.active.tails	: super.active
 
 	if (char.jumping)
 	{
@@ -85,7 +85,7 @@ function void Character.updateJumpMoves()
 				//  -> Can only be charged if there is no shield active (only exception: drop dash charge started already, when shield gets active -- this reflects Sonic Mania's behavior)
 				//  -> But can be charged if invincible (incl. Super / Hyper Sonic)
 				bool chargeDropDash = (control.player1.state & CONTROL_ABC) && (control.player1.state & CONTROL_UP) && ((char.bonus_effect & 0x70) == 0 || (char.bonus_effect & char.bonus.INVINCIBLE) || sonic.dropdash_counter > 0) && !(char.double_jump_state)
-                // This checks for Up being held.
+				// This checks for Up being held.
 				if (chargeDropDash)
 				{
 					if (sonic.dropdash_counter < DROPDASH_FULLCHARGE)

--- a/scripts/moves/peelout-cancel.lemon
+++ b/scripts/moves/peelout-cancel.lemon
@@ -1,0 +1,77 @@
+/*
+
+	This script file is part of the Sonic 3 A.I.R. Modders Resource. The Modders
+	Resource is a free resource library for any 3 A.I.R. modder, and for any
+	non-commercial purpose. No permission to use needed, no crediting required!
+
+	Come check it out at https://github.com/AirWay1/3AIR-Mod-Resources!
+
+*/
+
+// Author Notes
+/*
+
+	This prevents using the peel-out with B. When pressing B while charging up, the peel-out will be cancelled.
+
+*/
+
+function bool Character.updateSuperPeelout()
+{
+	u8 input_state   = control.player1.state
+	u8 input_pressed = control.player1.pressed
+
+	if (char.spindash == 0)
+	{
+		bool canStartPeelout = (char.state == char.state.LOOKING_UP) && (input_pressed & CONTROL_A || input_pressed & CONTROL_C) && (player1.control_override == 0)	// Last check is needed in cutscenes (e.g. end of MHZ 2)
+        // (input_pressed & CONTROL_ABC) is changed to (input_pressed & CONTROL_A || input_pressed & CONTROL_C) to prevent B from being used for peel-out.
+		if (!canStartPeelout)
+		{
+			// Nothing to see here
+			return false
+		}
+
+		char.state = char.state.RUNNING
+		char.spindash = 0x80
+		char.spindash_charge = 0
+		Audio.playAudio("peelout_charge", AudioContext.CONTEXT_SOUND)
+	}
+	else if (input_state & CONTROL_B && char.spindash == 0x80 && input_state & CONTROL_UP)
+    {
+        // If B is pressed while charging peelout, reset back to normal and return false.
+		char.state = char.state.STANDING
+		char.spindash = 0
+		char.spindash_charge = 0
+		char.groundspeed = 0
+		return false
+    }
+	else if (char.spindash == 0x80)
+	{
+		if (input_state & CONTROL_UP && !(nput_state & CONTROL_B))
+		{
+			// Charge up
+			char.spindash_charge = clamp(char.spindash_charge + 0x20, 0x100, 0x800)
+			if (char.flags & char.flag.UNDERWATER)
+			{
+				char.groundspeed = 0x100 + ((super.active) ? (char.spindash_charge) : (char.spindash_charge * 3/4))
+			}
+			else
+			{
+				char.groundspeed = 0x200 + ((super.active) ? (char.spindash_charge * 3/2) : (char.spindash_charge))
+			}
+			char.flags &= ~char.flag.PUSHING
+			if (abs(char.groundspeed) >= 0x0a00)
+				sonic.fastrunanim.timer = 30
+		}
+		else
+			releaseSuperPeelout()
+
+		// Center camera y-offset again
+		centerCameraYOffset()
+	}
+
+	Character.CheckAgainstMoveBorders()
+	Character.UpdateRotationOnGround()
+	partialUpdateCharacterOnGround()
+
+	return true
+}

--- a/scripts/moves/peelout-cancel.lemon
+++ b/scripts/moves/peelout-cancel.lemon
@@ -23,7 +23,7 @@ function bool Character.updateSuperPeelout()
 	if (char.spindash == 0)
 	{
 		bool canStartPeelout = (char.state == char.state.LOOKING_UP) && (input_pressed & CONTROL_A || input_pressed & CONTROL_C) && (player1.control_override == 0)	// Last check is needed in cutscenes (e.g. end of MHZ 2)
-        // (input_pressed & CONTROL_ABC) is changed to (input_pressed & CONTROL_A || input_pressed & CONTROL_C) to prevent B from being used for peel-out.
+		// (input_pressed & CONTROL_ABC) is changed to (input_pressed & CONTROL_A || input_pressed & CONTROL_C) to prevent B from being used for peel-out.
 		if (!canStartPeelout)
 		{
 			// Nothing to see here
@@ -36,14 +36,14 @@ function bool Character.updateSuperPeelout()
 		Audio.playAudio("peelout_charge", AudioContext.CONTEXT_SOUND)
 	}
 	else if (input_state & CONTROL_B && char.spindash == 0x80 && input_state & CONTROL_UP)
-    {
-        // If B is pressed while charging peelout, reset back to normal and return false.
+	{
+		// If B is pressed while charging peelout, reset back to normal and return false.
 		char.state = char.state.STANDING
 		char.spindash = 0
 		char.spindash_charge = 0
 		char.groundspeed = 0
 		return false
-    }
+	}
 	else if (char.spindash == 0x80)
 	{
 		if (input_state & CONTROL_UP && !(nput_state & CONTROL_B))


### PR DESCRIPTION
1103-inspired drop-dash:
You have to hold both Up and A, B or C at the same time in order to drop-dash. The peel-out is also disabled to prevent players from doing the peel-out on accident when trying to perform a drop-dash. You can re-enable it by simply removing the function Character.updateSuperPeelout() from the code, however.

S1 animations for Sonic:
Limits some of Sonic's animations down to their original frame count from S1.

Peel-out cancel:
If you press B while charging the peel-out, it will reset back to idle and cancel the peel-out.